### PR TITLE
[12.0][ADD] brand_external_report_layout_vat

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,36 +10,36 @@ This repository contains addons that extend / modify parts of
 
 * [account_cancel_permission](https://github.com/LuqueDaniel/odoo-custom-addons/tree/12.0/account_cancel_permission)
   (12.0.1.0.0)
-    * Only shows the button to cancel invoices, payments and bank statements to
+  * Only shows the button to cancel invoices, payments and bank statements to
       users with **Cancel Journal Entries** permission.
 * [account_invoice_financial_risk_filter](https://github.com/LuqueDaniel/odoo-custom-addons/tree/12.0/account_invoice_financial_risk_filter)
   (12.0.1.0.1)
-    * Adds the ability to filter invoices through the customer's policy field.
+  * Adds the ability to filter invoices through the customer's policy field.
 * [account_invoice_payment_partner_required](https://github.com/LuqueDaniel/odoo-custom-addons/tree/12.0/account_invoice_payment_partner_required)
   (12.0.1.0.0)
-    * Makes the Payment Mode and Payment Terms fields of the invoice mandatory.
+  * Makes the Payment Mode and Payment Terms fields of the invoice mandatory.
 * [account_payment_partner_required](https://github.com/LuqueDaniel/odoo-custom-addons/tree/12.0/account_payment_partner_required)
   (12.0.1.0.0)
-    * Makes the Partner Payment Mode and Partner Payment Terms fields mandatory.
+  * Makes the Partner Payment Mode and Partner Payment Terms fields mandatory.
 * [account_vendor_reference_required](https://github.com/LuqueDaniel/odoo-custom-addons/tree/12.0/account_vendor_reference_required)
   (12.0.1.0.0)
-    * Makes the Vendor Reference field mandatory.
+  * Makes the Vendor Reference field mandatory.
 * [brand_external_report_layout_vat](https://github.com/LuqueDaniel/odoo-custom-addons/tree/12.0/brand_external_report_layout_vat)
   * Display company vat in brand external layout.
 * [hide_cost_margin](https://github.com/LuqueDaniel/odoo-custom-addons/tree/12.0/hide_cost_margin)
   (12.0.1.0.0)
-    * Hides the cost and margin prices for all users who don't have the
+  * Hides the cost and margin prices for all users who don't have the
       `Show costs and margins` permission.
 * [l10n_es_gdpr_notification](https://github.com/LuqueDaniel/odoo-custom-addons/tree/12.0/l10n_es_gdpr_notification)
   (12.0.1.0.0)
-    * summary": """Adds GDPR notification to documents
+  * summary": """Adds GDPR notification to documents
 * [partner_tag_append_model](https://github.com/LuqueDaniel/odoo-custom-addons/tree/12.0/partner_tag_append_model)
   (12.0.1.0.0)
-    * Adds partner tag field to invoices and sale orders.
+  * Adds partner tag field to invoices and sale orders.
 * [vat_checker](https://github.com/LuqueDaniel/odoo-custom-addons/tree/12.0/vat_checker)
   (12.0.1.0.0)
-    * Check if the customer has a VAT before creating an invoice from a sale
-      order.
+  * Check if the customer has a VAT before creating an invoice from a sale
+    order.
 
 ## License
 
@@ -47,4 +47,4 @@ This repository contains addons that extend / modify parts of
 
 ## Thanks to
 
-- **OCA** Odoo Community Association (https://github.com/OCA)
+* [**OCA** Odoo Community Association](https://github.com/OCA)

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ This repository contains addons that extend / modify parts of
 * [account_vendor_reference_required](https://github.com/LuqueDaniel/odoo-custom-addons/tree/12.0/account_vendor_reference_required)
   (12.0.1.0.0)
     * Makes the Vendor Reference field mandatory.
+* [brand_external_report_layout_vat](https://github.com/LuqueDaniel/odoo-custom-addons/tree/12.0/brand_external_report_layout_vat)
+  * Display company vat in brand external layout.
 * [hide_cost_margin](https://github.com/LuqueDaniel/odoo-custom-addons/tree/12.0/hide_cost_margin)
   (12.0.1.0.0)
     * Hides the cost and margin prices for all users who don't have the

--- a/brand_external_report_layout_vat/README.md
+++ b/brand_external_report_layout_vat/README.md
@@ -1,0 +1,8 @@
+# Brand External Report Layout Va
+
+Extends `web.external_layout_ *` views to display company VAT in brand's
+external layouts.
+
+## Depends of
+
+* [brand_external_report_layout](https://github.com/OCA/brand/tree/12.0/brand_external_report_layout)

--- a/brand_external_report_layout_vat/__init__.py
+++ b/brand_external_report_layout_vat/__init__.py
@@ -1,0 +1,4 @@
+# Copyright 2020 ACT Bricolaje y Decoración
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+
+from . import models

--- a/brand_external_report_layout_vat/__manifest__.py
+++ b/brand_external_report_layout_vat/__manifest__.py
@@ -1,0 +1,16 @@
+# Copyright 2020 Daniel Luque
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+
+{
+    "name": "Brand External Report Layout Vat",
+    "summary": """Display company vat in brand external layout.""",
+    "description": """Extends `web.external_layout_ *` views to display
+    company VAT in brand's external layouts.
+    """,
+    "author": "Daniel Luque",
+    "license": "AGPL-3",
+    "website": "https://github.com/LuqueDaniel/odoo-custom-addons",
+    "version": "12.0.1.0.0",
+    "depends": ["brand_external_report_layout"],
+    "data": ["views/external_layouts.xml"],
+}

--- a/brand_external_report_layout_vat/models/__init__.py
+++ b/brand_external_report_layout_vat/models/__init__.py
@@ -1,0 +1,4 @@
+# Copyright 2020 ACT Bricolaje y Decoración
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+
+from . import res_brand

--- a/brand_external_report_layout_vat/models/res_brand.py
+++ b/brand_external_report_layout_vat/models/res_brand.py
@@ -1,0 +1,10 @@
+# Copyright 2020 ACT Bricolaje y Decoración
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+
+from odoo import fields, models
+
+
+class ResBrand(models.Model):
+    _inherit = "res.brand"
+
+    report_vat = fields.Char(related="company_id.vat", store=True)

--- a/brand_external_report_layout_vat/views/external_layouts.xml
+++ b/brand_external_report_layout_vat/views/external_layouts.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+    Copyright 2020 Daniel Luque
+    License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+-->
+
+<odoo>
+<template id="brand_external_layout_standard" inherit_id="web.external_layout_standard">
+    <xpath expr="//div[@name='company_address']" position="inside">
+        <span t-if="company.report_vat"><t t-esc="(company.country_id.vat_label or 'Tax ID').replace(' ','\N{NO-BREAK SPACE}')"/>: <span t-esc="company.report_vat.replace(' ','\N{NO-BREAK SPACE}')"/></span>
+    </xpath>
+</template>
+
+<template id="brand_external_layout_boxed" inherit_id="web.external_layout_boxed">
+    <xpath expr="//div[@name='company_address']" position="inside">
+        <span t-if="company.report_vat"><t t-esc="(company.country_id.vat_label or 'Tax ID').replace(' ','\N{NO-BREAK SPACE}')"/>: <span t-esc="company.report_vat.replace(' ','\N{NO-BREAK SPACE}')"/></span>
+    </xpath>
+</template>
+
+<template id="brand_external_layout_background" inherit_id="web.external_layout_background">
+    <xpath expr="//span[@t-field='company.partner_id']" position="after">
+        <span t-if="company.report_vat"><t t-esc="(company.country_id.vat_label or 'Tax ID').replace(' ','\N{NO-BREAK SPACE}')"/>: <span t-esc="company.report_vat.replace(' ','\N{NO-BREAK SPACE}')"/></span>
+    </xpath>
+</template>
+
+<template id="brand_external_layout_clean" inherit_id="web.external_layout_clean">
+    <xpath expr="//span[@t-field='company.partner_id']" position="after">
+        <span t-if="company.report_vat"><t t-esc="(company.country_id.vat_label or 'Tax ID').replace(' ','\N{NO-BREAK SPACE}')"/>: <span t-esc="company.report_vat.replace(' ','\N{NO-BREAK SPACE}')"/></span>
+    </xpath>
+</template>
+</odoo>

--- a/oca_dependencies.txt
+++ b/oca_dependencies.txt
@@ -2,3 +2,4 @@
 # add a github url if you need a forked version
 bank-payment
 credit-control
+brand


### PR DESCRIPTION
Adds `brand_external_report_layout_vat` addon that extends `web.external_layout_*` views to display company VAT in brand's external layouts.