### PR TITLE
addon: adds sale_account_brand_editable

### DIFF
--- a/sale_account_brand_editable/README.md
+++ b/sale_account_brand_editable/README.md
@@ -1,0 +1,8 @@
+# Sale and Account Brand Editable
+
+Allow you to edit 'brand_id' field in closed orders.
+
+## Depends of
+
+- [sale_brand](https://github.com/OCA/brand/tree/12.0)
+- [account_brand](https://github.com/OCA/brand/tree/12.0)

--- a/sale_account_brand_editable/__init__.py
+++ b/sale_account_brand_editable/__init__.py
@@ -1,0 +1,4 @@
+# Copyright 2020 Daniel Luque
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+
+from . import models

--- a/sale_account_brand_editable/__manifest__.py
+++ b/sale_account_brand_editable/__manifest__.py
@@ -1,0 +1,13 @@
+# Copyright 2020 Daniel Luque
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+
+{
+    "name": "Sales and Account Brand Editable",
+    "summary": """Allow to edit brand in closed orders.""",
+    "author": "Daniel Luque",
+    "license": "AGPL-3",
+    "website": "http://actgrupo.com/",
+    "category": "Accounting Management",
+    "version": "12.0.1.0.0",
+    "depends": ["sale_brand", "account_brand"],
+}

--- a/sale_account_brand_editable/models/__init__.py
+++ b/sale_account_brand_editable/models/__init__.py
@@ -1,0 +1,5 @@
+# Copyright 2020 Daniel Luque
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+
+from . import account_invoice
+from . import sale_order

--- a/sale_account_brand_editable/models/account_invoice.py
+++ b/sale_account_brand_editable/models/account_invoice.py
@@ -1,0 +1,17 @@
+# Copyright 2020 Daniel Luque
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+
+from odoo import fields, models
+
+
+class AccountInvoice(models.Model):
+    _inherit = "account.invoice"
+
+    brand_id = fields.Many2one(
+        states={
+            "open": [("readonly", False)],
+            "in_payment": [("readonly", False)],
+            "paid": [("readonly", False)],
+            "cancel": [("readonly", False)],
+        }
+    )

--- a/sale_account_brand_editable/models/sale_order.py
+++ b/sale_account_brand_editable/models/sale_order.py
@@ -1,0 +1,17 @@
+# Copyright 2020 Daniel Luque
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+
+from odoo import fields, models
+
+
+class SaleOrder(models.Model):
+    _inherit = "sale.order"
+
+    brand_id = fields.Many2one(
+        states={
+            "sent": [("readonly", False)],
+            "sale": [("readonly", False)],
+            "done": [("readonly", False)],
+            "cancel": [("readonly", False)],
+        }
+    )


### PR DESCRIPTION
This addon allow you to edit `brand_id` field in closed invoices or sale orders.