### PR TITLE
disable addon: brand_external_report_layout_vat

### DIFF
--- a/brand_external_report_layout_vat/__manifest__.py
+++ b/brand_external_report_layout_vat/__manifest__.py
@@ -10,4 +10,5 @@
     "version": "12.0.1.1.0",
     "depends": ["brand_external_report_layout"],
     "data": ["views/external_layouts.xml"],
+    "installable": False,
 }

--- a/l10n_es_gdpr_notification/__manifest__.py
+++ b/l10n_es_gdpr_notification/__manifest__.py
@@ -11,4 +11,5 @@
     "version": "12.0.1.0.2",
     "depends": ["sale", "stock", "account", "purchase"],
     "data": ["views/gdpr_documents_notification.xml"],
+    "installable": True,
 }

--- a/sale_account_brand_editable/__manifest__.py
+++ b/sale_account_brand_editable/__manifest__.py
@@ -10,4 +10,5 @@
     "category": "Accounting Management",
     "version": "12.0.1.0.0",
     "depends": ["sale_brand", "account_brand"],
+    "installable": True,
 }


### PR DESCRIPTION
Also adds the `installable` key to `__manifest__.py` in addons that didn't have it.