### PR TITLE
feat: add website_sale_brand addon

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ This repository contains addons that extend / modify parts of
 * [vat_checker](https://github.com/LuqueDaniel/odoo-custom-addons/tree/12.0/vat_checker)
   * Check if the customer has a VAT before creating an invoice from a sale
     order.
+* [website_sale_brand](https://github.com/LuqueDaniel/odoo-custom-addons/tree/12.0/website_sale_brand)
+  * Extends website sale order to add brand_id
 
 ## License
 

--- a/website_sale_brand/README.md
+++ b/website_sale_brand/README.md
@@ -1,0 +1,8 @@
+# Website Sale Brand
+
+Extends website sale order to add brand.
+
+## Depends of
+
+- [sale_brand](https://github.com/OCA/brand)
+- `website_sale`

--- a/website_sale_brand/__init__.py
+++ b/website_sale_brand/__init__.py
@@ -1,0 +1,4 @@
+# Copyright 2020 Daniel Luque
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+
+from . import models

--- a/website_sale_brand/__manifest__.py
+++ b/website_sale_brand/__manifest__.py
@@ -1,0 +1,14 @@
+# Copyright 2020 Daniel Luque
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+
+{
+    "name": "Website Sale Brand",
+    "summary": "Add brand to website sale order.",
+    "version": "12.0.1.0.0",
+    "category": "Website",
+    "website": "https://github.com/LuqueDaniel/odoo-custom-addons",
+    "author": "Daniel Luque",
+    "license": "AGPL-3",
+    "depends": ["sale_brand", "website_sale"],
+    "installable": True,
+}

--- a/website_sale_brand/models/__init__.py
+++ b/website_sale_brand/models/__init__.py
@@ -1,0 +1,4 @@
+# Copyright 2020 Daniel Luque
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+
+from . import website

--- a/website_sale_brand/models/website.py
+++ b/website_sale_brand/models/website.py
@@ -1,0 +1,21 @@
+# Copyright 2020 Daniel Luque
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+
+from odoo import api, models
+
+
+class ModuleName(models.Model):
+    _inherit = "website"
+
+    @api.multi
+    def _prepare_sale_order_values(self, partner, pricelist):
+        """Extends website sale order to adds brand."""
+        res = super()._prepare_sale_order_values(partner, pricelist)
+        brand = (
+            self.salesteam_id.brand_id
+            or partner.parent_id.team_id.brand_id
+            or partner.team_id.brand_id
+        )
+        if brand:
+            res["brand_id"] = brand.id
+        return res


### PR DESCRIPTION
An addon that let you use `brand_id` in Odoo website sale order.